### PR TITLE
Cp-43 feat/analysis 분석에 넘기는 commit 이력 변경 (기존 커밋 이력 전체 -> 특정 커밋)

### DIFF
--- a/src/analysis/analysis.controller.ts
+++ b/src/analysis/analysis.controller.ts
@@ -64,10 +64,37 @@ export class AnalysisController {
     @Param('prNumber') prNumber: string,
     @CurrentUser() user: any,
   ) {
+    const pullNumber = parseInt(prNumber, 10);
+    if (isNaN(pullNumber)) {
+      throw new Error('올바른 PR 번호를 입력해주세요.');
+    }
     return await this.analysisService.analyzeGitHubPullRequest(
       owner,
       repo,
-      parseInt(prNumber, 10),
+      pullNumber,
+      user.id,
+    );
+  }
+
+  /**
+   * GitHub PR의 최근 변경사항만 분석 (중복 제거)
+   */
+  @UseGuards(JwtAuthGuard)
+  @Get('github/pr/:owner/:repo/:prNumber/recent')
+  async analyzeGitHubPullRequestRecent(
+    @Param('owner') owner: string,
+    @Param('repo') repo: string,
+    @Param('prNumber') prNumber: string,
+    @CurrentUser() user: any,
+  ) {
+    const pullNumber = parseInt(prNumber, 10);
+    if (isNaN(pullNumber)) {
+      throw new Error('올바른 PR 번호를 입력해주세요.');
+    }
+    return await this.analysisService.analyzeGitHubPullRequestRecent(
+      owner,
+      repo,
+      pullNumber,
       user.id,
     );
   }

--- a/src/analysis/analysis.service.ts
+++ b/src/analysis/analysis.service.ts
@@ -147,6 +147,39 @@ export class AnalysisService {
     return result;
   }
 
+  // GitHub PR의 최근 변경사항만 분석 (중복 제거)
+  async analyzeGitHubPullRequestRecent(
+    owner: string,
+    repo: string,
+    pullNumber: number,
+    userId: string,
+  ): Promise<AnalyzeResponse[]> {
+    // GitHub에서 PR의 최근 변경된 파일들을 가져옴 (중복 제거)
+    const changedFiles = await this.githubService.getRecentChangedFilesInPullRequest(
+      owner,
+      repo,
+      pullNumber,
+      userId,
+    );
+
+    // C/C++ 파일만 필터링
+    const cppFiles = changedFiles.filter(
+      (file) => file.language === 'c' || file.language === 'cpp',
+    );
+
+    // AnalyzeRequest 형식으로 변환
+    const analyzeRequests: AnalyzeRequest[] = changedFiles
+      .filter((file) => file.language === 'c' || file.language === 'cpp')
+      .map((file) => ({
+        filename: file.filename,
+        content: file.content,
+        language: file.language as 'c' | 'cpp',
+      }));
+
+    const result = await this.analyzeFiles(analyzeRequests);
+    return result;
+  }
+
   async analysisGitHubChangedFile(
     owner: string,
     repo: string,

--- a/src/github/github.controller.ts
+++ b/src/github/github.controller.ts
@@ -414,6 +414,30 @@ export class GithubController {
     );
   }
 
+  /**
+   * PR 기준으로 최근 변경된 파일들 가져오기 (중복 제거)
+   */
+  @UseGuards(JwtAuthGuard)
+  @Get('repos/:owner/:repo/pulls/:pullNumber/recent-files')
+  async getRecentChangedFilesInPullRequest(
+    @Param('owner') owner: string,
+    @Param('repo') repo: string,
+    @Param('pullNumber') pullNumber: string,
+    @CurrentUser() user: any,
+  ) {
+    const pullNumberInt = parseInt(pullNumber, 10);
+    if (isNaN(pullNumberInt)) {
+      throw new Error('올바른 PR 번호를 입력해주세요.');
+    }
+    
+    return this.githubService.getRecentChangedFilesInPullRequest(
+      owner,
+      repo,
+      pullNumberInt,
+      user.id,
+    );
+  }
+
   @UseGuards(JwtAuthGuard)
   @Get('repos/:owner/:repo/pulls/:prNumber/files')
   async getFilesInPR(


### PR DESCRIPTION
기존 분석기 돌리는 함수는 커밋 이력 전체를 불러와서 검사기에 대한 정확한 정보 전달이 어려웠지만, 특정 커밋만 이제 넘기게 됨.

추후 오류메세지, 오류부분 지정등 개선할 사항 존재